### PR TITLE
Fix: space escaping in path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "localwp-shells",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "localwp-shells",
-      "version": "0.0.1",
+      "version": "0.0.2",
+      "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.6",
         "@types/node": "18.x",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,106 +4,107 @@ import * as path from "path";
 import * as os from "os";
 
 export function activate(context: vscode.ExtensionContext) {
-  const config = vscode.workspace.getConfiguration();
-  const folderPathConfig = config.get("localWPShells.folderPath") as string;
+	const config = vscode.workspace.getConfiguration();
+	const folderPathConfig = config.get("localWPShells.folderPath") as string;
 
-  if (!folderPathConfig) {
-    const homeDir = os.homedir();
-    const defaultPath = path.join(
-      homeDir,
-      "Library/Application Support/Local/ssh-entry"
-    );
-    config.update(
-      "localWPShells.folderPath",
-      defaultPath,
-      vscode.ConfigurationTarget.Global
-    );
-  }
+	if (!folderPathConfig) {
+		const homeDir = os.homedir();
+		const defaultPath = path.join(
+			homeDir,
+			"Library/Application Support/Local/ssh-entry"
+		);
+		config.update(
+			"localWPShells.folderPath",
+			defaultPath,
+			vscode.ConfigurationTarget.Global
+		);
+	}
 
-  let disposable = vscode.commands.registerCommand(
-    "localwp-shells.listSites",
-    async () => {
-      const folderPath = vscode.workspace
-        .getConfiguration()
-        .get("localWPShells.folderPath") as string;
+	let disposable = vscode.commands.registerCommand(
+		"localwp-shells.listSites",
+		async () => {
+			const folderPath = vscode.workspace
+				.getConfiguration()
+				.get("localWPShells.folderPath") as string;
 
-      if (!folderPath) {
-        vscode.window.showErrorMessage(
-          "Please set the folderPath in the settings."
-        );
-        return;
-      }
+			if (!folderPath) {
+				vscode.window.showErrorMessage(
+					"Please set the folderPath in the settings."
+				);
+				return;
+			}
 
-      try {
-        const files = await fs.promises.readdir(folderPath);
-        const shFiles = files.filter((file) => file.endsWith(".sh"));
+			try {
+				const files = await fs.promises.readdir(folderPath);
+				const shFiles = files.filter((file) => file.endsWith(".sh"));
 
-        if (shFiles.length === 0) {
-          vscode.window.showInformationMessage(
-            "No site shells found in the given path."
-          );
-          return;
-        }
+				if (shFiles.length === 0) {
+					vscode.window.showInformationMessage(
+						"No site shells found in the given path."
+					);
+					return;
+				}
 
-        const items = await Promise.all(
-          shFiles.map(async (file) => {
-            const filePath = path.join(folderPath, file);
-            const label = await getLabelFromFile(filePath);
-            return { label, description: filePath };
-          })
-        );
+				const items = await Promise.all(
+					shFiles.map(async (file) => {
+						const filePath = path.join(folderPath, file);
+						const label = await getLabelFromFile(filePath);
+						return { label, description: filePath };
+					})
+				);
 
-        const selected = await vscode.window.showQuickPick(items, {
-          placeHolder: "Select a script to run",
-        });
+				const selected = await vscode.window.showQuickPick(items, {
+					placeHolder: "Select a script to run",
+				});
 
-        if (selected) {
-          const terminal = vscode.window.createTerminal(
-            `Run ${selected.label}`
-          );
-          const escapedPath = `'${selected.description.replace(
-            /'/g,
-            "'\\''"
-          )}'`;
-          terminal.sendText(`sh ${escapedPath}`);
-          terminal.show();
+				if (selected) {
+					const terminal = vscode.window.createTerminal(
+						`Run ${selected.label}`
+					);
+					const pathWithoutSpaceEscapes = selected.description.replace(/\\ /g, ' ');
+					const escapedPath = `'${pathWithoutSpaceEscapes.replace(
+						/'/g,
+						"'\\''"
+					)}'`;
+					terminal.sendText(`sh ${escapedPath}`);
+					terminal.show();
 
-          // Display a message to the user to inform that site shell is opened.
-          vscode.window.showInformationMessage(
-            `Site shell for ${selected.label} is opened in the Terminal.`
-          );
-        }
-      } catch (error: any) {
-        vscode.window.showErrorMessage(
-          `Error reading folder: ${error.message}`
-        );
-      }
-    }
-  );
+					// Display a message to the user to inform that site shell is opened.
+					vscode.window.showInformationMessage(
+						`Site shell for ${selected.label} is opened in the Terminal.`
+					);
+				}
+			} catch (error: any) {
+				vscode.window.showErrorMessage(
+					`Error reading folder: ${error.message}`
+				);
+			}
+		}
+	);
 
-  context.subscriptions.push(disposable);
+	context.subscriptions.push(disposable);
 }
 
 async function getLabelFromFile(filePath: string): Promise<string> {
-  try {
-    const content = await fs.promises.readFile(filePath, "utf8");
-    const lines = content.split("\n");
-    for (const line of lines) {
-      if (line.startsWith("cd ")) {
-        const match = line.match(/cd\s+"?([^"]+?)\/app\/public"?/);
-        if (match && match[1]) {
-          const parts = match[1].split("/");
-          return parts[parts.length - 1]; // Extract the word before "/app/public"
-        }
-      }
-    }
-    return path.basename(filePath); // Fallback to filename if no match found
-  } catch (error: any) {
-    vscode.window.showErrorMessage(
-      `Error reading file ${filePath}: ${error.message}`
-    );
-    return path.basename(filePath);
-  }
+	try {
+		const content = await fs.promises.readFile(filePath, "utf8");
+		const lines = content.split("\n");
+		for (const line of lines) {
+			if (line.startsWith("cd ")) {
+				const match = line.match(/cd\s+"?([^"]+?)\/app\/public"?/);
+				if (match && match[1]) {
+					const parts = match[1].split("/");
+					return parts[parts.length - 1]; // Extract the word before "/app/public"
+				}
+			}
+		}
+		return path.basename(filePath); // Fallback to filename if no match found
+	} catch (error: any) {
+		vscode.window.showErrorMessage(
+			`Error reading file ${filePath}: ${error.message}`
+		);
+		return path.basename(filePath);
+	}
 }
 
 export function deactivate() {}


### PR DESCRIPTION
## Description

This PR updates the command path escaping logic in `src/extension.ts`:

- **Improved Path Handling:**  
  Previously, the path was escaped by replacing single quotes but did not account for any pre-existing escaped spaces (`\ `) in the path string.  
  Now, before escaping single quotes, the code first replaces all escaped spaces (`\ `) with regular spaces. This ensures the path used for the terminal command is correctly quoted and does not contain redundant backslashes.

```diff
- const escapedPath = `'${selected.description.replace(
+ const pathWithoutSpaceEscapes = selected.description.replace(/\\ /g, ' ');
+ const escapedPath = `'${pathWithoutSpaceEscapes.replace(
    /'/g,
    "'\\''"
  )}'`;
```

## Why?

- Fixes issues where file paths with spaces were incorrectly handled, leading to potential command failures in the integrated terminal.
- Makes command invocation more robust for file/folder names that contain spaces and/or single quotes.
